### PR TITLE
#35: Refactor into .h/.cpp pair for multiple TU usage

### DIFF
--- a/src/ESP8266Ping.cpp
+++ b/src/ESP8266Ping.cpp
@@ -17,8 +17,12 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <ESP8266Ping.h>
+
 extern "C" void esp_schedule();
 extern "C" void esp_yield();
+
+PingClass Ping;
 
 PingClass::PingClass() {}
 

--- a/src/ESP8266Ping.h
+++ b/src/ESP8266Ping.h
@@ -43,7 +43,6 @@ class PingClass {
     int minTime();
     int averageTime();
     int maxTime();
-    
 
   protected:
     static void _ping_sent_cb(void *opt, void *pdata);

--- a/src/ESP8266Ping.h
+++ b/src/ESP8266Ping.h
@@ -40,7 +40,10 @@ class PingClass {
     bool ping(IPAddress dest,   unsigned int count = 5);
     bool ping(const char* host, unsigned int count = 5);
 
+    int minTime();
     int averageTime();
+    int maxTime();
+    
 
   protected:
     static void _ping_sent_cb(void *opt, void *pdata);
@@ -50,7 +53,7 @@ class PingClass {
     ping_option _options;
 
     static byte _expected_count, _errors, _success;
-    static int _avg_time;
+    static uint _min_time, _avg_time, _max_time;
 };
 
 #include "ESP8266Ping.impl.h"

--- a/src/ESP8266Ping.h
+++ b/src/ESP8266Ping.h
@@ -55,7 +55,6 @@ class PingClass {
     static uint _min_time, _avg_time, _max_time;
 };
 
-#include "ESP8266Ping.impl.h"
-PingClass Ping;
+extern PingClass Ping;
 
 #endif

--- a/src/ESP8266Ping.h
+++ b/src/ESP8266Ping.h
@@ -37,8 +37,8 @@ class PingClass {
   public:
     PingClass();
 
-    bool ping(IPAddress dest,   byte count = 5);
-    bool ping(const char* host, byte count = 5);
+    bool ping(IPAddress dest,   unsigned int count = 5);
+    bool ping(const char* host, unsigned int count = 5);
 
     int averageTime();
 

--- a/src/ESP8266Ping.impl.h
+++ b/src/ESP8266Ping.impl.h
@@ -27,7 +27,10 @@ bool PingClass::ping(IPAddress dest, unsigned int count) {
     _errors = 0;
     _success = 0;
 
+    _min_time = INT_MAX;
     _avg_time = 0;
+    _max_time = 0;
+    
 
     memset(&_options, 0, sizeof(struct ping_option));
 
@@ -60,8 +63,16 @@ bool PingClass::ping(const char* host, unsigned int count) {
     return false;
 }
 
+int PingClass::minTime() {
+    return _min_time;
+}
+
 int PingClass::averageTime() {
     return _avg_time;
+}
+
+int PingClass::maxTime() {
+    return _max_time;
 }
 
 void PingClass::_ping_recv_cb(void *opt, void *resp) {
@@ -75,6 +86,11 @@ void PingClass::_ping_recv_cb(void *opt, void *resp) {
     else {
         _success++;
         _avg_time += ping_resp->resp_time;
+        if(ping_resp->resp_time < _min_time)
+          _min_time = ping_resp->resp_time;
+        if(ping_resp->resp_time > _max_time)
+          _max_time = ping_resp->resp_time;
+        
     }
 
     // Some debug info
@@ -98,7 +114,7 @@ void PingClass::_ping_recv_cb(void *opt, void *resp) {
     if (_success + _errors == _expected_count) {
         _avg_time = _success > 0 ? _avg_time / _success : 0;
 
-        DEBUG_PING("Avg resp time %d ms\n", _avg_time);
+        DEBUG_PING("Resp times min %d, ave %d, max %d ms\n", _min_time, _avg_time, _max_time);
 
         // Done, return to main functiom
         esp_schedule();
@@ -108,4 +124,6 @@ void PingClass::_ping_recv_cb(void *opt, void *resp) {
 byte PingClass::_expected_count = 0;
 byte PingClass::_errors = 0;
 byte PingClass::_success = 0;
-int  PingClass::_avg_time = 0;
+uint PingClass::_min_time = 0;
+uint PingClass::_avg_time = 0;
+uint PingClass::_max_time = 0;

--- a/src/ESP8266Ping.impl.h
+++ b/src/ESP8266Ping.impl.h
@@ -114,7 +114,7 @@ void PingClass::_ping_recv_cb(void *opt, void *resp) {
     if (_success + _errors == _expected_count) {
         _avg_time = _success > 0 ? _avg_time / _success : 0;
 
-        DEBUG_PING("Resp times min %d, ave %d, max %d ms\n", _min_time, _avg_time, _max_time);
+        DEBUG_PING("Resp times min %d, avg %d, max %d ms\n", _min_time, _avg_time, _max_time);
 
         // Done, return to main functiom
         esp_schedule();

--- a/src/ESP8266Ping.impl.h
+++ b/src/ESP8266Ping.impl.h
@@ -22,7 +22,7 @@ extern "C" void esp_yield();
 
 PingClass::PingClass() {}
 
-bool PingClass::ping(IPAddress dest, byte count) {
+bool PingClass::ping(IPAddress dest, unsigned int count) {
     _expected_count = count;
     _errors = 0;
     _success = 0;
@@ -51,7 +51,7 @@ bool PingClass::ping(IPAddress dest, byte count) {
     return (_success > 0);
 }
 
-bool PingClass::ping(const char* host, byte count) {
+bool PingClass::ping(const char* host, unsigned int count) {
     IPAddress remote_addr;
 
     if (WiFi.hostByName(host, remote_addr))


### PR DESCRIPTION
Fix for issue #35 

This removes code from the header file and places it into a .cpp file. Essentially removing the impl inclusion from the header and renaming it to .cpp. 

The global Ping instance is also moved to the .cpp file with the .h file just containing an `extern` reference to it.

This now allows the library to be included in multiple translation units without multiple-definition errors.