### PR TITLE
Async ping (non-blocking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,31 @@ After `Ping.ping()` has been called, the average response time (in milliseconds)
 ```Arduino
 int avg_time_ms = Ping.averageTime();
 ```
+
+You can run the ping in background, so you can do other stuff while waiting for the response:
+
+```Arduino
+void setup() {
+  // ...
+
+  bool ret = Ping.ping("www.google.com", 5, true); // async = true
+  if (ret) {
+    // ping started successfully
+  }
+}
+
+void loop() {
+
+  if (Ping.hasResult(true)) {
+    // ping is done, get the result
+    bool success = Ping.hasSuccess();
+
+    int avg_time_ms = Ping.averageTime();
+    int min_time_ms = Ping.minTime();
+    int max_time_ms = Ping.maxTime();
+  }
+
+  // do other stuff here
+  delay(200);
+}
+```

--- a/examples/AsyncPing/AsyncPing.ino
+++ b/examples/AsyncPing/AsyncPing.ino
@@ -1,0 +1,65 @@
+/*
+ * This example show how to ping a remote machine using it's hostname asynchrounously
+ */
+
+#include <ESP8266WiFi.h>
+#include <ESP8266Ping.h>
+
+const char* ssid     = "ssid";
+const char* password = "passphrase";
+
+const char* remote_host = "www.google.com";
+
+void setup()
+{
+  Serial.begin(115200);
+  delay(10);
+
+  // We start by connecting to a WiFi network
+
+  Serial.println();
+  Serial.println("Connecting to WiFi");
+  
+  WiFi.begin(ssid, password);
+  
+  while (WiFi.status() != WL_CONNECTED)
+  {
+    delay(100);
+    Serial.print(".");
+  }
+
+  Serial.println();
+  Serial.print("WiFi connected with ip ");  
+  Serial.println(WiFi.localIP());
+
+  Serial.print("Pinging host ");
+  Serial.println(remote_host);
+
+  if(Ping.ping(remote_host, 5, true))
+  {
+    Serial.println("Ping is running!!");
+  } else
+  {
+    Serial.println("Ping is not running :(");
+  }
+}
+
+void loop()
+{
+
+  // check if ping has a result (and reset the result flag)
+  if (Ping.hasResult(true)) {
+
+    bool ret = Ping.hasSuccess();
+
+    int avg_time_ms = Ping.averageTime();
+    int min_time_ms = Ping.minTime();
+    int max_time_ms = Ping.maxTime();
+
+    // ...
+  }
+
+  // do something else 
+  delay(100);
+
+}

--- a/src/ESP8266Ping.h
+++ b/src/ESP8266Ping.h
@@ -39,12 +39,15 @@ class PingClass
   public:
     PingClass();
 
-    bool ping(IPAddress dest,   unsigned int count = 5);
-    bool ping(const char* host, unsigned int count = 5);
+    bool ping(IPAddress dest,   unsigned int count = 5, bool async = false);
+    bool ping(const char* host, unsigned int count = 5, bool async = false);
 
     int minTime();
     int averageTime();
     int maxTime();
+
+    bool hasSuccess();
+    bool hasResult(bool clear = true);
 
   protected:
     static void _ping_sent_cb(void *opt, void *pdata);
@@ -57,6 +60,7 @@ class PingClass
     uint _min_time, _avg_time, _max_time;
 
     bool _done;
+    bool _has_result;
 };
 
 extern PingClass Ping;


### PR DESCRIPTION
Hey :-)

I've added a few things to support async ping. It shouldn't change any existing functionality.
A third param disables the `while`-loop with the delay that waits for the `_done` flag to become `true`.
Then we can just check for the results with the `Ping.hasResult()` method and optionally clear the result flag using `Ping.hasResult(true)`.

When the `async` flag is set to `true`, the return value of `Ping.ping()` indicates if the start of the pinging was successful or not. It will return `false` if theres another ping currently active.

```Arduino
void setup() {
  // ...

  bool ret = Ping.ping("www.google.com", 5, true); // async = true
  if (ret) {
    // ping started successfully
  }
}

void loop() {

  if (Ping.hasResult(true)) {
    // ping is done, get the result
    bool success = Ping.hasSuccess();

    // do something with the result
  }

  // do other stuff here
  delay(200);
}
```